### PR TITLE
Replace __restrict__ keyword by preprocessor definition FASTOR_RESTRICT

### DIFF
--- a/backend/adjoint.h
+++ b/backend/adjoint.h
@@ -11,13 +11,13 @@ namespace Fastor {
 
 
 template<typename T, size_t M, size_t N>
-FASTOR_HINT_INLINE void _adjoint(const T * __restrict__ a, T * __restrict__ out) {
+FASTOR_HINT_INLINE void _adjoint(const T * FASTOR_RESTRICT a, T * FASTOR_RESTRICT out) {
     assert(false && "METHOD NOT YET IMPLEMENTED");
 }
 
 #ifdef __SSE4_2__
 template<>
-FASTOR_HINT_INLINE void _adjoint<float,2,2>(const float * __restrict__ a, float * __restrict__ out) {
+FASTOR_HINT_INLINE void _adjoint<float,2,2>(const float * FASTOR_RESTRICT a, float * FASTOR_RESTRICT out) {
     // 4 OPS
     __m128 a_reg = _mm_load_ps(a);
     __m128 a0 = _mm_shuffle_ps(a_reg,a_reg,_MM_SHUFFLE(0,3,2,1));
@@ -26,7 +26,7 @@ FASTOR_HINT_INLINE void _adjoint<float,2,2>(const float * __restrict__ a, float 
 }
 
 template<>
-FASTOR_HINT_INLINE void _adjoint<float,3,3>(const float * __restrict__ a, float * __restrict__ out) {
+FASTOR_HINT_INLINE void _adjoint<float,3,3>(const float * FASTOR_RESTRICT a, float * FASTOR_RESTRICT out) {
     // 110 OPS
     __m128 a_low = _mm_load_ps(a);
     __m128 a_high = _mm_load_ps(a+4);
@@ -83,7 +83,7 @@ FASTOR_HINT_INLINE void _adjoint<float,3,3>(const float * __restrict__ a, float 
 }
 
 template<>
-FASTOR_HINT_INLINE void _adjoint<double,2,2>(const double * __restrict__ a, double * __restrict__ out) {
+FASTOR_HINT_INLINE void _adjoint<double,2,2>(const double * FASTOR_RESTRICT a, double * FASTOR_RESTRICT out) {
     // 2 OPS
     _mm_store_sd(out+3,_mm_load_sd(a));
     _mm_store_sd(out,_mm_load_sd(a+3));
@@ -92,7 +92,7 @@ FASTOR_HINT_INLINE void _adjoint<double,2,2>(const double * __restrict__ a, doub
 }
 
 template<>
-FASTOR_HINT_INLINE void _adjoint<double,3,3>(const double * __restrict__ a, double * __restrict__ out) {
+FASTOR_HINT_INLINE void _adjoint<double,3,3>(const double * FASTOR_RESTRICT a, double * FASTOR_RESTRICT out) {
     // 96 OPS
     __m128d a00 = _mm_load_sd(a);
     __m128d a01 = _mm_load_sd(a+1);

--- a/backend/cofactor.h
+++ b/backend/cofactor.h
@@ -10,13 +10,13 @@ namespace Fastor {
 
 
 template<typename T, size_t M, size_t N>
-FASTOR_HINT_INLINE void _cofactor(const T * __restrict__ a, T * __restrict__ out) {
+FASTOR_HINT_INLINE void _cofactor(const T * FASTOR_RESTRICT a, T * FASTOR_RESTRICT out) {
     assert(false && "METHOD NOT YET IMPLEMENTED");
 }
 
 #ifdef __SSE4_2__
 template<>
-FASTOR_HINT_INLINE void _cofactor<float,2,2>(const float * __restrict__ a, float * __restrict__ out) {
+FASTOR_HINT_INLINE void _cofactor<float,2,2>(const float * FASTOR_RESTRICT a, float * FASTOR_RESTRICT out) {
     // 4 OPS
     __m128 a_reg = _mm_load_ps(a);
     __m128 a0 = _mm_shuffle_ps(a_reg,a_reg,_MM_SHUFFLE(0,3,2,1));
@@ -25,7 +25,7 @@ FASTOR_HINT_INLINE void _cofactor<float,2,2>(const float * __restrict__ a, float
 }
 
 template<>
-FASTOR_HINT_INLINE void _cofactor<float,3,3>(const float * __restrict__ a, float * __restrict__ out) {
+FASTOR_HINT_INLINE void _cofactor<float,3,3>(const float * FASTOR_RESTRICT a, float * FASTOR_RESTRICT out) {
     // 110 OPS
     __m128 a_low = _mm_load_ps(a);
     __m128 a_high = _mm_load_ps(a+4);
@@ -82,7 +82,7 @@ FASTOR_HINT_INLINE void _cofactor<float,3,3>(const float * __restrict__ a, float
 }
 
 template<>
-FASTOR_HINT_INLINE void _cofactor<double,2,2>(const double * __restrict__ a, double * __restrict__ out) {
+FASTOR_HINT_INLINE void _cofactor<double,2,2>(const double * FASTOR_RESTRICT a, double * FASTOR_RESTRICT out) {
     // 2 OPS
     _mm_store_sd(out+3,_mm_load_sd(a));
     _mm_store_sd(out,_mm_load_sd(a+3));
@@ -91,7 +91,7 @@ FASTOR_HINT_INLINE void _cofactor<double,2,2>(const double * __restrict__ a, dou
 }
 
 template<>
-FASTOR_HINT_INLINE void _cofactor<double,3,3>(const double * __restrict__ a, double * __restrict__ out) {
+FASTOR_HINT_INLINE void _cofactor<double,3,3>(const double * FASTOR_RESTRICT a, double * FASTOR_RESTRICT out) {
     // 96 OPS
     __m128d a00 = _mm_load_sd(a);
     __m128d a01 = _mm_load_sd(a+1);

--- a/backend/cyclic_0.h
+++ b/backend/cyclic_0.h
@@ -10,7 +10,7 @@ namespace Fastor {
 //! Version 0 of cyclic product of two second order tensors i.e. C_ijkl = A_ik * B_jl
 
 template<typename T, size_t M0, size_t N0, size_t M1, size_t N1>
-FASTOR_HINT_INLINE void _cyclic(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+FASTOR_HINT_INLINE void _cyclic(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
     for (size_t i=0; i<M0; ++i) {
         for (size_t j=0; j<N0; ++j) {
             for (size_t k=0; k<M1; ++k) {
@@ -24,7 +24,7 @@ FASTOR_HINT_INLINE void _cyclic(const T * __restrict__ a, const T * __restrict__
 
 #ifdef __AVX__
 template<>
-FASTOR_HINT_INLINE void _cyclic<double,2,2,2,2>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+FASTOR_HINT_INLINE void _cyclic<double,2,2,2,2>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     __m256d as = _mm256_load_pd(a);
     __m256d bs = _mm256_load_pd(b);
 
@@ -55,7 +55,7 @@ FASTOR_HINT_INLINE void _cyclic<double,2,2,2,2>(const double * __restrict__ a, c
 }
 
 template<>
-FASTOR_HINT_INLINE void _cyclic<double,3,3,3,3>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+FASTOR_HINT_INLINE void _cyclic<double,3,3,3,3>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     //  34+ OPS
     __m256d a_low = _mm256_load_pd(a);
     __m256d a_high = _mm256_load_pd(a+4);

--- a/backend/determinant.h
+++ b/backend/determinant.h
@@ -7,11 +7,11 @@
 namespace Fastor {
 
 template<typename T, size_t M, size_t N>
-FASTOR_INLINE T _det(const T* __restrict__ a);
+FASTOR_INLINE T _det(const T* FASTOR_RESTRICT a);
 
 #ifdef __AVX__
 template<>
-FASTOR_INLINE float _det<float,2,2>(const float* __restrict__ a) {
+FASTOR_INLINE float _det<float,2,2>(const float* FASTOR_RESTRICT a) {
     // 10 OPS
     __m128 a1 = _mm_load_ps(a);
     __m128 a2 = _mm_shuffle_ps(a1,a1,_MM_SHUFFLE(0,1,2,3));
@@ -20,7 +20,7 @@ FASTOR_INLINE float _det<float,2,2>(const float* __restrict__ a) {
 }
 
 template<>
-FASTOR_INLINE float _det<float,3,3>(const float* __restrict__ a) {
+FASTOR_INLINE float _det<float,3,3>(const float* FASTOR_RESTRICT a) {
     // ?? OPS
     __m128 r0 = {a[2],a[1],a[0],0.};
     __m128 r1 = {a[3],a[5],a[4],0.};
@@ -37,7 +37,7 @@ FASTOR_INLINE float _det<float,3,3>(const float* __restrict__ a) {
 }
 
 template<>
-FASTOR_INLINE double _det<double,2,2>(const double* __restrict__ a) {
+FASTOR_INLINE double _det<double,2,2>(const double* FASTOR_RESTRICT a) {
     // 10 OPS
     __m128d a1 = _mm_load_pd(a);
     __m128d a2 = _mm_load_pd(a+2);
@@ -46,7 +46,7 @@ FASTOR_INLINE double _det<double,2,2>(const double* __restrict__ a) {
 }
 
 template<>
-FASTOR_INLINE double _det<double,3,3>(const double* __restrict__ a) {
+FASTOR_INLINE double _det<double,3,3>(const double* FASTOR_RESTRICT a) {
     // ?? OPS
     __m256d r0 = {a[2],a[1],a[0],0.};
     __m256d r1 = {a[3],a[5],a[4],0.};
@@ -65,21 +65,21 @@ FASTOR_INLINE double _det<double,3,3>(const double* __restrict__ a) {
 #else
 
 template<>
-FASTOR_INLINE float _det<float,2,2>(const float* __restrict__ a) {
+FASTOR_INLINE float _det<float,2,2>(const float* FASTOR_RESTRICT a) {
     return a[0] * a[3] - a[1] * a[2];
 }
 template<>
-FASTOR_INLINE float _det<float,3,3>(const float* __restrict__ a) {
+FASTOR_INLINE float _det<float,3,3>(const float* FASTOR_RESTRICT a) {
     return a[0]*a[4]*a[8] + a[1]*a[5]*a[6] + a[2]*a[3]*a[7] - a[2]*a[4]*a[6] - a[1]*a[3]*a[8] - a[0]*a[5]*a[7];
 }
 
 
 template<>
-FASTOR_INLINE double _det<double,2,2>(const double* __restrict__ a) {
+FASTOR_INLINE double _det<double,2,2>(const double* FASTOR_RESTRICT a) {
     return a[0] * a[3] - a[1] * a[2];
 }
 template<>
-FASTOR_INLINE double _det<double,3,3>(const double* __restrict__ a) {
+FASTOR_INLINE double _det<double,3,3>(const double* FASTOR_RESTRICT a) {
     return a[0]*a[4]*a[8] + a[1]*a[5]*a[6] + a[2]*a[3]*a[7] - a[2]*a[4]*a[6] - a[1]*a[3]*a[8] - a[0]*a[5]*a[7];
 }
 

--- a/backend/doublecontract.h
+++ b/backend/doublecontract.h
@@ -7,7 +7,7 @@
 namespace Fastor {
 
 template<typename T, size_t M, size_t N>
-FASTOR_INLINE T _doublecontract(const T* __restrict__ a, const T* __restrict__ b) {
+FASTOR_INLINE T _doublecontract(const T* FASTOR_RESTRICT a, const T* FASTOR_RESTRICT b) {
 
     using V = SIMDVector<T,DEFAULT_ABI>;
     constexpr int size = M*N;
@@ -34,24 +34,24 @@ FASTOR_INLINE T _doublecontract(const T* __restrict__ a, const T* __restrict__ b
 #ifdef __AVX__
 
 template<>
-FASTOR_INLINE float _doublecontract<float,2,2>(const float* __restrict__ a, const float* __restrict__ b) {
+FASTOR_INLINE float _doublecontract<float,2,2>(const float* FASTOR_RESTRICT a, const float* FASTOR_RESTRICT b) {
     return _mm_sum_ps(_mm_mul_ps(_mm_load_ps(a),_mm_load_ps(b)));
 }
 
 template<>
-FASTOR_INLINE float _doublecontract<float,3,3>(const float* __restrict__ a, const float* __restrict__ b) {
+FASTOR_INLINE float _doublecontract<float,3,3>(const float* FASTOR_RESTRICT a, const float* FASTOR_RESTRICT b) {
     float r1 = _mm256_sum_ps(_mm256_mul_ps(_mm256_load_ps(a),_mm256_load_ps(b)));
     float r2 = _mm_sum_ps(_mm_mul_ss(_mm_load_ss(a+8),_mm_load_ss(b+8)));
     return r1+r2;
 }
 
 template<>
-FASTOR_INLINE double _doublecontract<double,2,2>(const double* __restrict__ a, const double* __restrict__ b) {
+FASTOR_INLINE double _doublecontract<double,2,2>(const double* FASTOR_RESTRICT a, const double* FASTOR_RESTRICT b) {
     return _mm256_sum_pd(_mm256_mul_pd(_mm256_load_pd(a),_mm256_load_pd(b)));
 }
 
 template<>
-FASTOR_INLINE double _doublecontract<double,3,3>(const double* __restrict__ a, const double* __restrict__ b) {
+FASTOR_INLINE double _doublecontract<double,3,3>(const double* FASTOR_RESTRICT a, const double* FASTOR_RESTRICT b) {
     __m256d r1 = _mm256_mul_pd(_mm256_load_pd(a),_mm256_load_pd(b));
     __m256d r2 = _mm256_mul_pd(_mm256_load_pd(a+4),_mm256_load_pd(b+4));
     __m128d r3 = _mm_mul_sd(_mm_load_sd(a+8),_mm_load_sd(b+8));
@@ -65,7 +65,7 @@ FASTOR_INLINE double _doublecontract<double,3,3>(const double* __restrict__ a, c
 
 // doublecontract and transpose
 template<typename T, size_t M, size_t N>
-FASTOR_INLINE T _doublecontract_transpose(const T* __restrict__ a, const T* __restrict__ b) {
+FASTOR_INLINE T _doublecontract_transpose(const T* FASTOR_RESTRICT a, const T* FASTOR_RESTRICT b) {
     T dc = static_cast<T>(0);
     for (FASTOR_INDEX i=0; i<M; ++i)
         for (FASTOR_INDEX j=0; j<N; ++j)

--- a/backend/dyadic.h
+++ b/backend/dyadic.h
@@ -13,7 +13,7 @@ namespace Fastor {
 
 template<typename T, size_t size0, size_t size1>
 FASTOR_INLINE
-void _dyadic(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _dyadic(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
     using V  = SIMDVector<T,256>;
     constexpr int VSIZE = static_cast<int>(V::Size);
@@ -103,7 +103,7 @@ void _dyadic(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 // Outer product (2x2) x (2x2)
 template<>
 FASTOR_INLINE
-void _dyadic<float,4,4>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+void _dyadic<float,4,4>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
 
     __m128 vec_a = _mm_load_ps(a);
     __m128 vec_b = _mm_load_ps(b);
@@ -129,7 +129,7 @@ void _dyadic<float,4,4>(const float * __restrict__ a, const float * __restrict__
 // Outer product (2x2) x (2x2)
 template<>
 FASTOR_INLINE
-void _dyadic<double,4,4>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+void _dyadic<double,4,4>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
 
     __m256d vec_b = _mm256_load_pd(b);
 
@@ -149,7 +149,7 @@ void _dyadic<double,4,4>(const double * __restrict__ a, const double * __restric
 // Outer product (1x2) x (1x2) [for vectors]
 template<>
 FASTOR_INLINE
-void _dyadic<float,2,2>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+void _dyadic<float,2,2>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
     // 7 OPS
     __m128 vec_a = _mm_load_ps(a);
     __m128 vec_b = _mm_load_ps(b);
@@ -164,7 +164,7 @@ void _dyadic<float,2,2>(const float * __restrict__ a, const float * __restrict__
 // Outer product (1x2) x (1x2) [for vectors]
 template<>
 FASTOR_INLINE
-void _dyadic<double,2,2>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+void _dyadic<double,2,2>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     // IVY 9 OPS / HW 13 OPS
     __m128d vec_a = _mm_load_pd(a);
     __m128d vec_b = _mm_load_pd(b);
@@ -184,7 +184,7 @@ void _dyadic<double,2,2>(const double * __restrict__ a, const double * __restric
 // Outer product (1x3) x (1x3) [for vectors]
 template<>
 FASTOR_INLINE
-void _dyadic<float,3,3>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+void _dyadic<float,3,3>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
     // 18 OPS
     __m128 vec_a = _mm_load_ps(a);
     __m128 vec_b = _mm_load_ps(b);
@@ -202,7 +202,7 @@ void _dyadic<float,3,3>(const float * __restrict__ a, const float * __restrict__
 // Outer product (1x3) x (1x3) [for vectors]
 template<>
 FASTOR_INLINE
-void _dyadic<double,3,3>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+void _dyadic<double,3,3>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     // 15 OPS + set OPS
     __m256d vec_b = _mm256_load_pd(b);
     __m256d a0 = _mm256_set1_pd(a[0]);
@@ -221,12 +221,12 @@ void _dyadic<double,3,3>(const double * __restrict__ a, const double * __restric
 // Outer product of scalars
 template<>
 FASTOR_INLINE
-void _dyadic<double,1,1>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+void _dyadic<double,1,1>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     out[0] = a[0]*b[0];
 }
 template<>
 FASTOR_INLINE
-void _dyadic<float,1,1>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+void _dyadic<float,1,1>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
     out[0] = a[0]*b[0];
 }
 

--- a/backend/inverse.h
+++ b/backend/inverse.h
@@ -7,10 +7,10 @@
 namespace Fastor {
 
 template<typename T, size_t N>
-FASTOR_INLINE void _inverse(const T *__restrict__ src, T *__restrict__ dst);
+FASTOR_INLINE void _inverse(const T *FASTOR_RESTRICT src, T *FASTOR_RESTRICT dst);
 
 template<>
-FASTOR_INLINE void _inverse<double,2>(const double *__restrict__ src, double *__restrict__ dst)
+FASTOR_INLINE void _inverse<double,2>(const double *FASTOR_RESTRICT src, double *FASTOR_RESTRICT dst)
 {
     double det;
 
@@ -42,7 +42,7 @@ FASTOR_INLINE void _inverse<double,2>(const double *__restrict__ src, double *__
 
 
 template<>
-FASTOR_INLINE void _inverse<double,3>(const double *__restrict__ src, double *__restrict__ dst)
+FASTOR_INLINE void _inverse<double,3>(const double *FASTOR_RESTRICT src, double *FASTOR_RESTRICT dst)
 {
     double det;
 

--- a/backend/matmul.h
+++ b/backend/matmul.h
@@ -13,7 +13,7 @@ namespace Fastor {
 template<typename T, size_t M, size_t K, size_t N,
          typename std::enable_if<M==N && M==K && N % SIMDVector<T,DEFAULT_ABI>::Size ==0,bool>::type = 0>
 FASTOR_INLINE
-void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ c) {
+void _matmul(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT c) {
 
     using V = SIMDVector<T,DEFAULT_ABI>;
     constexpr size_t UnrollOuterloop = V::size();
@@ -73,7 +73,7 @@ void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 template<typename T, size_t M, size_t K, size_t N,
          typename std::enable_if<(M!=K && M==N && M==2 && std::is_same<T,double>::value),bool>::type = 0>
 FASTOR_INLINE
-void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
     __m128d out_row0 = ZEROPD;
     __m128d out_row1 = ZEROPD;
@@ -105,7 +105,7 @@ void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 template<typename T, size_t M, size_t K, size_t N,
          typename std::enable_if<(M!=K && M==N && M==2 && std::is_same<T,float>::value),bool>::type = 0>
 FASTOR_INLINE
-void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
     __m128 out_row0 = ZEROPS;
     __m128 out_row1 = ZEROPS;
@@ -139,7 +139,7 @@ void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 template<typename T, size_t M, size_t K, size_t N,
          typename std::enable_if<(M!=K && M==N && M==3 && std::is_same<T,double>::value),bool>::type = 0>
 FASTOR_INLINE
-void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
     __m256d out_row0 = VZEROPD;
     __m256d out_row1 = VZEROPD;
@@ -182,7 +182,7 @@ void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 template<typename T, size_t M, size_t K, size_t N,
          typename std::enable_if<(M!=K && M==N && M==3 && std::is_same<T,float>::value),bool>::type = 0>
 FASTOR_INLINE
-void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
     __m128 out_row0 = ZEROPS;
     __m128 out_row1 = ZEROPS;
@@ -226,7 +226,7 @@ void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 template<typename T, size_t M, size_t K, size_t N,
          typename std::enable_if<(M!=K && M==N && M==4 && std::is_same<T,double>::value),bool>::type = 0>
 FASTOR_INLINE
-void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
     __m256d out_row0 = VZEROPD;
     __m256d out_row1 = VZEROPD;
@@ -276,7 +276,7 @@ void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 template<typename T, size_t M, size_t K, size_t N,
          typename std::enable_if<(M!=K && M==N && M==4 && std::is_same<T,float>::value),bool>::type = 0>
 FASTOR_INLINE
-void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
     __m128 out_row0 = ZEROPS;
     __m128 out_row1 = ZEROPS;
@@ -361,7 +361,7 @@ void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 // (2x2) x (2xn) matrices
 template<typename T, size_t M, size_t N>
 FASTOR_INLINE
-void _matmul_2x2xn(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul_2x2xn(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
 
     using V256 = SIMDVector<T,256>;
@@ -426,7 +426,7 @@ void _matmul_2x2xn(const T * __restrict__ a, const T * __restrict__ b, T * __res
 // (3x3) x (3xn) matrices
 template<typename T, size_t M, size_t N>
 FASTOR_INLINE
-void _matmul_3x3xn(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul_3x3xn(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
 
     using V256 = SIMDVector<T,256>;
@@ -506,7 +506,7 @@ template<typename T, size_t M, size_t K, size_t N,
                                  || (M!=K && M==N && M!=2 && M!=3 && M!=4)
                                  || ((M==N && M==K) && N % SIMDVector<T,DEFAULT_ABI>::Size !=0),bool>::type = 0>
 FASTOR_INLINE
-void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+void _matmul(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
 
     // The following specialisations don't make much of a difference (at least for SP)
     // Need thorough performance checks
@@ -856,7 +856,7 @@ void _matmul(const T * __restrict__ a, const T * __restrict__ b, T * __restrict_
 
 template<>
 FASTOR_INLINE
-void _matmul<float,2,2,2>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+void _matmul<float,2,2,2>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
 
 #ifndef USE_OLD_VERSION
     // 17 OPS
@@ -887,7 +887,7 @@ void _matmul<float,2,2,2>(const float * __restrict__ a, const float * __restrict
 
 template<>
 FASTOR_INLINE
-void _matmul<float,3,3,3>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+void _matmul<float,3,3,3>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
 
 #ifndef USE_OLD_VERSION
     // 63 OPS + 3 OPS
@@ -1055,7 +1055,7 @@ void _matmul<float,3,3,3>(const float * __restrict__ a, const float * __restrict
 #ifdef __AVX__
 template<>
 FASTOR_INLINE
-void _matmul<double,2,2,2>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+void _matmul<double,2,2,2>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
 
 #ifndef USE_OLD_VERSION
 
@@ -1106,7 +1106,7 @@ void _matmul<double,2,2,2>(const double * __restrict__ a, const double * __restr
 
 template<>
 FASTOR_INLINE
-void _matmul<double,3,3,3>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+void _matmul<double,3,3,3>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
 
 
 #ifndef USE_OLD_VERSION
@@ -1215,7 +1215,7 @@ void _matmul<double,3,3,3>(const double * __restrict__ a, const double * __restr
 
 #ifdef __SSE4_2__
 template<>
-FASTOR_INLINE void _matmul<float,4,4,4>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+FASTOR_INLINE void _matmul<float,4,4,4>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
 
     __m128 a0 = _mm_load_ps(a);
     __m128 a1 = _mm_load_ps(a+4);
@@ -1319,7 +1319,7 @@ FASTOR_INLINE void _matmul<float,4,4,4>(const float * __restrict__ a, const floa
 #ifdef __SSE4_2__
 template<>
 FASTOR_INLINE
-void _matmul<float,2,2,1>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+void _matmul<float,2,2,1>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
     // 11 OPS
     __m128 a_reg = _mm_load_ps(a);
     __m128 vec_b = _mm_load_ps(b);
@@ -1333,7 +1333,7 @@ void _matmul<float,2,2,1>(const float * __restrict__ a, const float * __restrict
 }
 
 template<>
-FASTOR_INLINE void _matmul<float,3,3,1>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+FASTOR_INLINE void _matmul<float,3,3,1>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
     // 47 OPS
     __m128 a0 = _mm_load_ps(a);
     __m128 row0 = _mm_shift1_ps(a0);
@@ -1356,7 +1356,7 @@ FASTOR_INLINE void _matmul<float,3,3,1>(const float * __restrict__ a, const floa
 #endif
 #ifdef __AVX__
 template<>
-FASTOR_INLINE void _matmul<double,2,2,1>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+FASTOR_INLINE void _matmul<double,2,2,1>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     // IVY 15 OPS - HW 19 OPS
     __m256d a_reg = _mm256_load_pd(a);
     __m128d b_vec = _mm_load_pd(b);
@@ -1370,7 +1370,7 @@ FASTOR_INLINE void _matmul<double,2,2,1>(const double * __restrict__ a, const do
 
 
 template<>
-FASTOR_INLINE void _matmul<double,3,3,1>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+FASTOR_INLINE void _matmul<double,3,3,1>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     // IVY 58 OPS - HW 84 OPS
     __m128d a0 = _mm_load_pd(a);
     __m128d a1 = _mm_load_sd(a+2);

--- a/backend/norm.h
+++ b/backend/norm.h
@@ -8,7 +8,7 @@
 namespace Fastor {
 
 template<typename T, size_t N>
-FASTOR_INLINE double _norm_nonfloating(const T* __restrict__ a) {
+FASTOR_INLINE double _norm_nonfloating(const T* FASTOR_RESTRICT a) {
 
     using V = SIMDVector<T,DEFAULT_ABI>;
     constexpr int size = N;
@@ -31,7 +31,7 @@ FASTOR_INLINE double _norm_nonfloating(const T* __restrict__ a) {
 
 
 template<typename T, size_t N>
-FASTOR_INLINE T _norm(const T* __restrict__ a) {
+FASTOR_INLINE T _norm(const T* FASTOR_RESTRICT a) {
 
     using V = SIMDVector<T,DEFAULT_ABI>;
     constexpr int size = N;
@@ -58,7 +58,7 @@ FASTOR_INLINE T _norm(const T* __restrict__ a) {
 
 #ifdef __SSE4_2__
 template<>
-FASTOR_INLINE float _norm<float,4>(const float * __restrict__ a) {
+FASTOR_INLINE float _norm<float,4>(const float * FASTOR_RESTRICT a) {
     // IVY 33 OPS / HW 31 OPS
     __m128 a_reg = _mm_load_ps(a);
     return _mm_cvtss_f32(_mm_sqrt_ps(_add_ps(_mm_mul_ps(a_reg,a_reg))));
@@ -66,7 +66,7 @@ FASTOR_INLINE float _norm<float,4>(const float * __restrict__ a) {
 #endif
 #ifdef __AVX__
 template<>
-FASTOR_INLINE float _norm<float,9>(const float * __restrict__ a) {
+FASTOR_INLINE float _norm<float,9>(const float * FASTOR_RESTRICT a) {
     // IVY & HW 61 OPS
     __m256 a_reg = _mm256_load_ps(a);
     __m128 a_end = _mm_load_ss(a+8);
@@ -77,14 +77,14 @@ FASTOR_INLINE float _norm<float,9>(const float * __restrict__ a) {
 
 
 template<>
-FASTOR_INLINE double _norm<double,4>(const double * __restrict__ a) {
+FASTOR_INLINE double _norm<double,4>(const double * FASTOR_RESTRICT a) {
     // IVY 34 OPS / HW 36 OPS
     __m256d a_reg = _mm256_load_pd(a);
     return _mm_cvtsd_f64(_mm_sqrt_pd(_add_pd(_mm256_mul_pd(a_reg,a_reg))));
 }
 
 template<>
-FASTOR_INLINE double _norm<double,9>(const double * __restrict__ a) {
+FASTOR_INLINE double _norm<double,9>(const double * FASTOR_RESTRICT a) {
     // IVY 63 OPS / HW 67 OPS
     __m256d a_low = _mm256_load_pd(a);
     __m256d a_high = _mm256_load_pd(a+4);

--- a/backend/outer.h
+++ b/backend/outer.h
@@ -7,7 +7,7 @@ namespace Fastor {
 
 
 template<typename T, size_t M0, size_t N0, size_t M1, size_t N1>
-FASTOR_HINT_INLINE void _outer(const T * __restrict__ a, const T * __restrict__ b, T * __restrict__ out) {
+FASTOR_HINT_INLINE void _outer(const T * FASTOR_RESTRICT a, const T * FASTOR_RESTRICT b, T * FASTOR_RESTRICT out) {
     for (size_t i=0; i<M0; ++i) {
         for (size_t j=0; j<N0; ++j) {
             for (size_t k=0; k<M1; ++k) {
@@ -24,7 +24,7 @@ FASTOR_HINT_INLINE void _outer(const T * __restrict__ a, const T * __restrict__ 
 // The followings are Voigt overloads
 
 template<>
-FASTOR_HINT_INLINE void _outer<float,2,2,2,2>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+FASTOR_HINT_INLINE void _outer<float,2,2,2,2>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
     // 31 OPS
     // Fetch a to L1-cache
 //    _mm_prefetch(a,_MM_HINT_T0);
@@ -59,7 +59,7 @@ FASTOR_HINT_INLINE void _outer<float,2,2,2,2>(const float * __restrict__ a, cons
 }
 
 template<>
-FASTOR_HINT_INLINE void _outer<float,3,3,3,3>(const float * __restrict__ a, const float * __restrict__ b, float * __restrict__ out) {
+FASTOR_HINT_INLINE void _outer<float,3,3,3,3>(const float * FASTOR_RESTRICT a, const float * FASTOR_RESTRICT b, float * FASTOR_RESTRICT out) {
     // 81 OPS
     // Fetch a to L1-cache
 //    _mm_prefetch(a,_MM_HINT_T0);
@@ -196,7 +196,7 @@ FASTOR_HINT_INLINE void _outer<float,3,3,3,3>(const float * __restrict__ a, cons
 #endif
 #ifdef __AVX__
 template<>
-FASTOR_HINT_INLINE void _outer<double,2,2,2,2>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+FASTOR_HINT_INLINE void _outer<double,2,2,2,2>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     // Fetch a to L1-cache
 //    _mm_prefetch(a,_MM_HINT_T0);
     __m256d a0 = _mm256_set1_pd(a[0]);
@@ -224,7 +224,7 @@ FASTOR_HINT_INLINE void _outer<double,2,2,2,2>(const double * __restrict__ a, co
 }
 
 template<>
-FASTOR_HINT_INLINE void _outer<double,3,3,3,3>(const double * __restrict__ a, const double * __restrict__ b, double * __restrict__ out) {
+FASTOR_HINT_INLINE void _outer<double,3,3,3,3>(const double * FASTOR_RESTRICT a, const double * FASTOR_RESTRICT b, double * FASTOR_RESTRICT out) {
     //  OPS
 //    _mm_prefetch(a,_MM_HINT_T0);
 

--- a/backend/tensor_cross.h
+++ b/backend/tensor_cross.h
@@ -7,14 +7,14 @@
 namespace Fastor {
 
 template<typename T, size_t M, size_t K, size_t N>
-inline void _crossproduct(const T *__restrict__ a, const T *__restrict__ b, T *__restrict__ c) {
+inline void _crossproduct(const T *FASTOR_RESTRICT a, const T *FASTOR_RESTRICT b, T *FASTOR_RESTRICT c) {
     assert(false && "CROSS PRODUCT IS ONLY A 3D OPERATOR");
 }
 
 #ifdef __SSE4_2__
 
 template<>
-FASTOR_INLINE void _crossproduct<double,2,2,2>(const double *__restrict__ a, const double *__restrict__ b, double *__restrict__ c) {
+FASTOR_INLINE void _crossproduct<double,2,2,2>(const double *FASTOR_RESTRICT a, const double *FASTOR_RESTRICT b, double *FASTOR_RESTRICT c) {
     // 25 OPS without HADD / 27 OPS with HADD
     // Load a data - c has to have 9 elements as
     __m128d a_00 = _mm_load_sd(a);
@@ -56,7 +56,7 @@ FASTOR_INLINE void _crossproduct<double,2,2,2>(const double *__restrict__ a, con
 }
 
 template<>
-FASTOR_INLINE void _crossproduct<double,3,3,3>(const double *__restrict__ a, const double *__restrict__ b, double *__restrict__ c) {
+FASTOR_INLINE void _crossproduct<double,3,3,3>(const double *FASTOR_RESTRICT a, const double *FASTOR_RESTRICT b, double *FASTOR_RESTRICT c) {
     // 225 OPS without HADD / 243 OPS with HADD
     // Load a data
     __m128d a_00 = _mm_load_sd(a);
@@ -189,7 +189,7 @@ FASTOR_INLINE void _crossproduct<double,3,3,3>(const double *__restrict__ a, con
 
 
 template<>
-FASTOR_INLINE void _crossproduct<float,2,2,2>(const float *__restrict__ a, const float *__restrict__ b, float *__restrict__ c) {
+FASTOR_INLINE void _crossproduct<float,2,2,2>(const float *FASTOR_RESTRICT a, const float *FASTOR_RESTRICT b, float *FASTOR_RESTRICT c) {
     // 15 OPS + 4 extra shuffle to make aligned loading = 19 OPS
     __m128 a0 = _mm_load_ps(a);
     __m128 tmp0 = _mm_load_ps(a+4);
@@ -216,7 +216,7 @@ FASTOR_INLINE void _crossproduct<float,2,2,2>(const float *__restrict__ a, const
 }
 
 template<>
-FASTOR_INLINE void _crossproduct<float,3,3,3>(const float *__restrict__ a, const float *__restrict__ b, float *__restrict__ c) {
+FASTOR_INLINE void _crossproduct<float,3,3,3>(const float *FASTOR_RESTRICT a, const float *FASTOR_RESTRICT b, float *FASTOR_RESTRICT c) {
     // 135 OPS + 6 extra shuffle to make aligned loading = 141 OPS
     // Don't unalign load - Bad performance on IVY
 
@@ -276,10 +276,10 @@ FASTOR_INLINE void _crossproduct<float,3,3,3>(const float *__restrict__ a, const
 //-----------------------------------------------------------------------------------------------
 // for plane strain problems
 template<typename T, int ProblemType>
-void _crossproduct(const T *__restrict__ a, const T *__restrict__ b, T *__restrict__ c);
+void _crossproduct(const T *FASTOR_RESTRICT a, const T *FASTOR_RESTRICT b, T *FASTOR_RESTRICT c);
 
 template<>
-FASTOR_INLINE void _crossproduct<double,PlaneStrain>(const double *__restrict__ a, const double *__restrict__ b, double *__restrict__ c) {
+FASTOR_INLINE void _crossproduct<double,PlaneStrain>(const double *FASTOR_RESTRICT a, const double *FASTOR_RESTRICT b, double *FASTOR_RESTRICT c) {
     // For plane strain problems a and b need to be 3D with last element a[8]=b[8]=1
     // This is a cross product implementation not a cofactor so the result needs to multiplied by 0.5 explicitly
     // if the cofactor is desired
@@ -338,7 +338,7 @@ FASTOR_INLINE void _crossproduct<double,PlaneStrain>(const double *__restrict__ 
 
 
 template<>
-FASTOR_INLINE void _crossproduct<float,PlaneStrain>(const float *__restrict__ a, const float *__restrict__ b, float *__restrict__ c) {
+FASTOR_INLINE void _crossproduct<float,PlaneStrain>(const float *FASTOR_RESTRICT a, const float *FASTOR_RESTRICT b, float *FASTOR_RESTRICT c) {
     // For plane strain problems a and b need to be 3D with last element a[8]=b[8]=1
     // This is a cross product implementation not a cofactor so the result needs to multiplied by 0.5 explicitly
     // if the cofactor is desired
@@ -396,7 +396,7 @@ FASTOR_INLINE void _crossproduct<float,PlaneStrain>(const float *__restrict__ a,
 
 // vectors and 2nd order tensors
 template<>
-FASTOR_HINT_INLINE void _crossproduct<float,3,1,3>(const float *__restrict__ a, const float *__restrict__ b, float *__restrict__ c) {
+FASTOR_HINT_INLINE void _crossproduct<float,3,1,3>(const float *FASTOR_RESTRICT a, const float *FASTOR_RESTRICT b, float *FASTOR_RESTRICT c) {
     // vector-tensor cross product - regitster based
     float A1 = a[0];
     float A2 = a[1];
@@ -428,7 +428,7 @@ FASTOR_HINT_INLINE void _crossproduct<float,3,1,3>(const float *__restrict__ a, 
 }
 
 template<>
-FASTOR_HINT_INLINE void _crossproduct<float,2,1,2>(const float *__restrict__ a, const float *__restrict__ b, float *__restrict__ c) {
+FASTOR_HINT_INLINE void _crossproduct<float,2,1,2>(const float *FASTOR_RESTRICT a, const float *FASTOR_RESTRICT b, float *FASTOR_RESTRICT c) {
     // vector-tensor cross product - regitster based
     float A1 = a[0];
     float A2 = a[1];
@@ -450,7 +450,7 @@ FASTOR_HINT_INLINE void _crossproduct<float,2,1,2>(const float *__restrict__ a, 
 }
 
 template<>
-FASTOR_HINT_INLINE void _crossproduct<double,3,1,3>(const double *__restrict__ a, const double *__restrict__ b, double *__restrict__ c) {
+FASTOR_HINT_INLINE void _crossproduct<double,3,1,3>(const double *FASTOR_RESTRICT a, const double *FASTOR_RESTRICT b, double *FASTOR_RESTRICT c) {
     // vector-tensor cross product - regitster based
     double A1 = a[0];
     double A2 = a[1];
@@ -482,7 +482,7 @@ FASTOR_HINT_INLINE void _crossproduct<double,3,1,3>(const double *__restrict__ a
 }
 
 template<>
-FASTOR_HINT_INLINE void _crossproduct<double,2,1,2>(const double *__restrict__ a, const double *__restrict__ b, double *__restrict__ c) {
+FASTOR_HINT_INLINE void _crossproduct<double,2,1,2>(const double *FASTOR_RESTRICT a, const double *FASTOR_RESTRICT b, double *FASTOR_RESTRICT c) {
     // vector-tensor cross product - regitster based
     double A1 = a[0];
     double A2 = a[1];
@@ -505,7 +505,7 @@ FASTOR_HINT_INLINE void _crossproduct<double,2,1,2>(const double *__restrict__ a
 
 //
 template<>
-FASTOR_HINT_INLINE void _crossproduct<float,3,3,1>(const float *__restrict__ a, const float *__restrict__ b, float *__restrict__ c) {
+FASTOR_HINT_INLINE void _crossproduct<float,3,3,1>(const float *FASTOR_RESTRICT a, const float *FASTOR_RESTRICT b, float *FASTOR_RESTRICT c) {
     // tensor-vector cross product - regitster based
     float B1 = b[0];
     float B2 = b[1];
@@ -538,7 +538,7 @@ FASTOR_HINT_INLINE void _crossproduct<float,3,3,1>(const float *__restrict__ a, 
 
 
 template<>
-FASTOR_HINT_INLINE void _crossproduct<float,2,2,1>(const float *__restrict__ a, const float *__restrict__ b, float *__restrict__ c) {
+FASTOR_HINT_INLINE void _crossproduct<float,2,2,1>(const float *FASTOR_RESTRICT a, const float *FASTOR_RESTRICT b, float *FASTOR_RESTRICT c) {
     // tensor-vector cross product - regitster based
     float B1 = b[0];
     float B2 = b[1];
@@ -560,7 +560,7 @@ FASTOR_HINT_INLINE void _crossproduct<float,2,2,1>(const float *__restrict__ a, 
 }
 
 template<>
-FASTOR_HINT_INLINE void _crossproduct<double,3,3,1>(const double *__restrict__ a, const double *__restrict__ b, double *__restrict__ c) {
+FASTOR_HINT_INLINE void _crossproduct<double,3,3,1>(const double *FASTOR_RESTRICT a, const double *FASTOR_RESTRICT b, double *FASTOR_RESTRICT c) {
     // tensor-vector cross product - regitster based
     double B1 = b[0];
     double B2 = b[1];
@@ -592,7 +592,7 @@ FASTOR_HINT_INLINE void _crossproduct<double,3,3,1>(const double *__restrict__ a
 }
 
 template<>
-FASTOR_HINT_INLINE void _crossproduct<double,2,2,1>(const double *__restrict__ a, const double *__restrict__ b, double *__restrict__ c) {
+FASTOR_HINT_INLINE void _crossproduct<double,2,2,1>(const double *FASTOR_RESTRICT a, const double *FASTOR_RESTRICT b, double *FASTOR_RESTRICT c) {
     // tensor-vector cross product - regitster based
     double B1 = b[0];
     double B2 = b[1];
@@ -623,7 +623,7 @@ FASTOR_HINT_INLINE void _crossproduct<double,2,2,1>(const double *__restrict__ a
 //(AxB)_{PiIQ} = E_{ijk}E_{IJK}A_{PjJ}B_{kKQ}
 // tensor cross product of 3rd order tensors
 template<typename T, size_t I, size_t J, size_t K, size_t L, size_t M, size_t N>
-FASTOR_HINT_INLINE void _crossproduct(const T *__restrict__ A, const T *__restrict__ B, T *__restrict__ C) {
+FASTOR_HINT_INLINE void _crossproduct(const T *FASTOR_RESTRICT A, const T *FASTOR_RESTRICT B, T *FASTOR_RESTRICT C) {
 
     T _A000 = A[0];
     T _A001 = A[1];
@@ -773,7 +773,7 @@ FASTOR_HINT_INLINE void _crossproduct(const T *__restrict__ A, const T *__restri
 //(AxB)_{pPiIqQ} = E_{ijk}E_{IJK}A_{pPjJ}B_{kKqQ}
 // tensor cross product of 4th order tensors
 template<typename T, size_t I, size_t J, size_t K, size_t L, size_t M, size_t N, size_t O, size_t P>
-FASTOR_HINT_INLINE void _crossproduct(const T *__restrict__ A, const T *__restrict__ B, T *__restrict__ C) {
+FASTOR_HINT_INLINE void _crossproduct(const T *FASTOR_RESTRICT A, const T *FASTOR_RESTRICT B, T *FASTOR_RESTRICT C) {
 
     T _A0000 = A[0];
     T _A0001 = A[1];

--- a/backend/trace.h
+++ b/backend/trace.h
@@ -8,7 +8,7 @@ namespace Fastor {
 
 
 template<typename T, size_t M, size_t N, typename std::enable_if<M==N,bool>::type=0>
-FASTOR_INLINE T _trace(const T * __restrict__ a) {
+FASTOR_INLINE T _trace(const T * FASTOR_RESTRICT a) {
     T sum = static_cast<T>(0);
     for (FASTOR_INDEX i=0; i<M; ++i)
         sum +=a[i*N+i];
@@ -17,7 +17,7 @@ FASTOR_INLINE T _trace(const T * __restrict__ a) {
 
 #ifdef __SSE4_2__
 template<>
-FASTOR_INLINE double _trace<double,2,2>(const double * __restrict__ a) {
+FASTOR_INLINE double _trace<double,2,2>(const double * FASTOR_RESTRICT a) {
     // AVX VERSION
     // IVY 5 OPS / HW 7 OPS
 //    __m256d a_reg = _mm256_load_pd(a);
@@ -32,13 +32,13 @@ FASTOR_INLINE double _trace<double,2,2>(const double * __restrict__ a) {
 }
 
 template<>
-FASTOR_INLINE double _trace<double,3,3>(const double * __restrict__ a) {
+FASTOR_INLINE double _trace<double,3,3>(const double * FASTOR_RESTRICT a) {
     // No benefit in AVX
     return _mm_cvtsd_f64(_mm_add_sd(_mm_load_sd(a),_mm_add_sd(_mm_load_sd(a+4),_mm_load_sd(a+8))));
 }
 
 template<>
-FASTOR_INLINE float _trace<float,2,2>(const float * __restrict__ a) {
+FASTOR_INLINE float _trace<float,2,2>(const float * FASTOR_RESTRICT a) {
     __m128 a_reg = _mm_load_ps(a);
     return _mm_cvtss_f32(_mm_add_ss(a_reg,_mm_reverse_ps(a_reg)));
 }
@@ -46,7 +46,7 @@ FASTOR_INLINE float _trace<float,2,2>(const float * __restrict__ a) {
 
 #ifdef __AVX__
 template<>
-FASTOR_INLINE float _trace<float,3,3>(const float * __restrict__ a) {
+FASTOR_INLINE float _trace<float,3,3>(const float * FASTOR_RESTRICT a) {
     __m256 a_reg = _mm256_load_ps(a);
     __m128 sum_two = _mm_add_ps(_mm256_castps256_ps128(a_reg),_mm256_extractf128_ps(a_reg,0x1));
     return _mm_cvtss_f32(_mm_add_ss(sum_two,_mm_load_ss(a+8)));

--- a/backend/transpose.h
+++ b/backend/transpose.h
@@ -8,7 +8,7 @@
 namespace Fastor {
 
 template<typename T, size_t M, size_t N>
-FASTOR_INLINE void _transpose(const T * __restrict__ a, T * __restrict__ out) {
+FASTOR_INLINE void _transpose(const T * FASTOR_RESTRICT a, T * FASTOR_RESTRICT out) {
     for (size_t i=0; i< M; ++i)
         for (size_t j=0; j<N; ++j)
             out[j*M+i] = a[i*N+j];
@@ -16,13 +16,13 @@ FASTOR_INLINE void _transpose(const T * __restrict__ a, T * __restrict__ out) {
 
 #ifdef __SSE4_2__
 template<>
-FASTOR_INLINE void _transpose<float,2,2>(const float * __restrict__ a, float * __restrict__ out) {
+FASTOR_INLINE void _transpose<float,2,2>(const float * FASTOR_RESTRICT a, float * FASTOR_RESTRICT out) {
     __m128 a_reg = _mm_load_ps(a);
     _mm_store_ps(out,_mm_shuffle_ps(a_reg,a_reg,_MM_SHUFFLE(3,1,2,0)));
 }
 
 template<>
-FASTOR_INLINE void _transpose<float,3,3>(const float * __restrict__ a, float * __restrict__ out) {
+FASTOR_INLINE void _transpose<float,3,3>(const float * FASTOR_RESTRICT a, float * FASTOR_RESTRICT out) {
     __m128 a_low = _mm_load_ps(a);
     __m128 a_high = _mm_load_ps(a+4);
     __m128 a_end = _mm_load_ss(a+8);
@@ -38,7 +38,7 @@ FASTOR_INLINE void _transpose<float,3,3>(const float * __restrict__ a, float * _
 }
 
 template<>
-FASTOR_INLINE void _transpose<float,4,4>(const float * __restrict__ a, float * __restrict__ out) {
+FASTOR_INLINE void _transpose<float,4,4>(const float * FASTOR_RESTRICT a, float * FASTOR_RESTRICT out) {
     __m128 row1 = _mm_load_ps(a);
     __m128 row2 = _mm_load_ps(a+4);
     __m128 row3 = _mm_load_ps(a+8);
@@ -53,7 +53,7 @@ FASTOR_INLINE void _transpose<float,4,4>(const float * __restrict__ a, float * _
 
 #ifdef __AVX__
 template<>
-FASTOR_INLINE void _transpose<float,8,8>(const float * __restrict__ a, float * __restrict__ out) {
+FASTOR_INLINE void _transpose<float,8,8>(const float * FASTOR_RESTRICT a, float * FASTOR_RESTRICT out) {
     __m256 row1 = _mm256_load_ps(a);
     __m256 row2 = _mm256_load_ps(a+8);
     __m256 row3 = _mm256_load_ps(a+16);
@@ -75,7 +75,7 @@ FASTOR_INLINE void _transpose<float,8,8>(const float * __restrict__ a, float * _
 
 
 template<>
-FASTOR_INLINE void _transpose<double,2,2>(const double* __restrict__ a, double* __restrict__ out) {
+FASTOR_INLINE void _transpose<double,2,2>(const double* FASTOR_RESTRICT a, double* FASTOR_RESTRICT out) {
     // IVY 4 OPS / HW 8 OPS
     __m256d a1 =  _mm256_load_pd(a);
     __m128d a2 =  _mm256_castpd256_pd128(a1);
@@ -90,7 +90,7 @@ FASTOR_INLINE void _transpose<double,2,2>(const double* __restrict__ a, double* 
 
 #ifdef __SSE4_2__
 template<>
-FASTOR_INLINE void _transpose<double,3,3>(const double* __restrict__ a, double* __restrict__ out) {
+FASTOR_INLINE void _transpose<double,3,3>(const double* FASTOR_RESTRICT a, double* FASTOR_RESTRICT out) {
     /*-------------------------------------------------------*/
     // SSE VERSION - Requires 32byte alignment
     // all loads are 16 byte aligned if a is 32byte aligned
@@ -133,7 +133,7 @@ FASTOR_INLINE void _transpose<double,3,3>(const double* __restrict__ a, double* 
 
 #ifdef __AVX__
 template<>
-FASTOR_INLINE void _transpose<double,4,4>(const double * __restrict__ a, double * __restrict__ out) {
+FASTOR_INLINE void _transpose<double,4,4>(const double * FASTOR_RESTRICT a, double * FASTOR_RESTRICT out) {
     __m256d row1 = _mm256_load_pd(a);
     __m256d row2 = _mm256_load_pd(a+4);
     __m256d row3 = _mm256_load_pd(a+8);

--- a/backend/voigt.h
+++ b/backend/voigt.h
@@ -38,7 +38,7 @@ struct VoigtType<T,3,3> {
 template<typename T, size_t ... Rest,
          typename std::enable_if<sizeof...(Rest)==4 && prod<Rest...>::value == 16
                                  ,bool>::type=0>
-FASTOR_INLINE void _voigt(const T * __restrict__ a_data, T * __restrict__ VoigtA) {
+FASTOR_INLINE void _voigt(const T * FASTOR_RESTRICT a_data, T * FASTOR_RESTRICT VoigtA) {
     VoigtA[0] = a_data[0];
     VoigtA[1] = a_data[3];
     VoigtA[2] = 0.5*(a_data[1]+a_data[2]);
@@ -54,7 +54,7 @@ FASTOR_INLINE void _voigt(const T * __restrict__ a_data, T * __restrict__ VoigtA
 template<typename T, size_t ... Rest,
          typename std::enable_if<sizeof...(Rest)==4 && prod<Rest...>::value == 81
                                  ,bool>::type=0>
-FASTOR_INLINE void _voigt(const T * __restrict__ a_data, T * __restrict__ VoigtA) {
+FASTOR_INLINE void _voigt(const T * FASTOR_RESTRICT a_data, T * FASTOR_RESTRICT VoigtA) {
 
     VoigtA[0] = a_data[0];
     VoigtA[1] = a_data[4];
@@ -98,7 +98,7 @@ FASTOR_INLINE void _voigt(const T * __restrict__ a_data, T * __restrict__ VoigtA
 template<typename T, size_t ... Rest,
          typename std::enable_if<sizeof...(Rest)==3 && prod<Rest...>::value == 8
                                  ,bool>::type=0>
-FASTOR_INLINE void _voigt(const T * __restrict__ e, T * __restrict__ VoigtA) {
+FASTOR_INLINE void _voigt(const T * FASTOR_RESTRICT e, T * FASTOR_RESTRICT VoigtA) {
 
     // 3rd order tensor to 2nd order tensor
     // 3rd order tensor should be symmetric in the first two indices
@@ -114,7 +114,7 @@ FASTOR_INLINE void _voigt(const T * __restrict__ e, T * __restrict__ VoigtA) {
 template<typename T, size_t ... Rest,
          typename std::enable_if<sizeof...(Rest)==3 && prod<Rest...>::value == 27
                                  ,bool>::type=0>
-FASTOR_INLINE void _voigt(const T * __restrict__ e, T * __restrict__ VoigtA) {
+FASTOR_INLINE void _voigt(const T * FASTOR_RESTRICT e, T * FASTOR_RESTRICT VoigtA) {
 
     // 3rd order tensor to 2nd order tensor
     // 3rd order tensor should be symmetric in the first two indices
@@ -142,7 +142,7 @@ FASTOR_INLINE void _voigt(const T * __restrict__ e, T * __restrict__ VoigtA) {
 template<typename T, size_t ... Rest,
          typename std::enable_if<sizeof...(Rest)==2 && prod<Rest...>::value == 4
                                  ,bool>::type=0>
-FASTOR_INLINE void _voigt(const T * __restrict__ e, T * __restrict__ VoigtA) {
+FASTOR_INLINE void _voigt(const T * FASTOR_RESTRICT e, T * FASTOR_RESTRICT VoigtA) {
 
     VoigtA[0] = e[0];
     VoigtA[1] = e[3];
@@ -153,7 +153,7 @@ FASTOR_INLINE void _voigt(const T * __restrict__ e, T * __restrict__ VoigtA) {
 template<typename T, size_t ... Rest,
          typename std::enable_if<sizeof...(Rest)==2 && prod<Rest...>::value == 9
                                  ,bool>::type=0>
-FASTOR_INLINE void _voigt(const T * __restrict__ e, T * __restrict__ VoigtA) {
+FASTOR_INLINE void _voigt(const T * FASTOR_RESTRICT e, T * FASTOR_RESTRICT VoigtA) {
 
     VoigtA[0] = e[0];
     VoigtA[1] = e[4];

--- a/commons/commons.h
+++ b/commons/commons.h
@@ -41,6 +41,12 @@
 #endif
 
 #if defined(__GNUC__) || defined(__GNUG__)
+#define FASTOR_RESTRICT __restrict__
+#elif defined(_MSC_VER)
+#define FASTOR_RESTRICT __restrict
+#endif
+
+#if defined(__GNUC__) || defined(__GNUG__)
     #define FASTOR_ALIGN __attribute__((aligned(0x20)))
 #elif defined(_MSC_VER)
     #define FASTOR_ALIGN __declspec(align(32))

--- a/simd_vector/SIMDVector.h
+++ b/simd_vector/SIMDVector.h
@@ -242,13 +242,13 @@ FASTOR_INLINE void vector_setter(SIMDVector<T,ABI> &vec, const T *data, const st
 // 4 word scalar
 template<typename T, int ABI, typename Int,
          typename std::enable_if<sizeof(T)==4 && ABI==32,bool>::type=0>
-FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &vec, Int idx, int ) {
+FASTOR_INLINE void data_setter(T *FASTOR_RESTRICT data, const SIMDVector<T,ABI> &vec, Int idx, int ) {
     data[idx] = vec.value;
 }
 // 4 word SSE
 template<typename T, int ABI, typename Int,
          typename std::enable_if<sizeof(T)==4 && ABI==128,bool>::type=0>
-FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride=1) {
+FASTOR_INLINE void data_setter(T *FASTOR_RESTRICT data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride=1) {
     data[idx] = vec[0];
     data[idx+general_stride] = vec[1];
     data[idx+2*general_stride] = vec[2];
@@ -257,7 +257,7 @@ FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &ve
 // 4 word AVX
 template<typename T, int ABI, typename Int,
          typename std::enable_if<sizeof(T)==4 && ABI==256,bool>::type=0>
-FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride=1) {
+FASTOR_INLINE void data_setter(T *FASTOR_RESTRICT data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride=1) {
     data[idx] = vec[0];
     data[idx+general_stride] = vec[1];
     data[idx+2*general_stride] = vec[2];
@@ -270,7 +270,7 @@ FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &ve
 // 4 word AVX 512
 template<typename T, int ABI, typename Int,
          typename std::enable_if<sizeof(T)==4 && ABI==512,bool>::type=0>
-FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride=1) {
+FASTOR_INLINE void data_setter(T *FASTOR_RESTRICT data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride=1) {
     data[idx] = vec[0];
     data[idx+general_stride] = vec[1];
     data[idx+2*general_stride] = vec[2];
@@ -292,20 +292,20 @@ FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &ve
 // 8 word scalar
 template<typename T, int ABI, typename Int,
          typename std::enable_if<sizeof(T)==8 && ABI==64,bool>::type=0>
-FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &vec, Int idx, int ) {
+FASTOR_INLINE void data_setter(T *FASTOR_RESTRICT data, const SIMDVector<T,ABI> &vec, Int idx, int ) {
     data[idx] = vec.value;
 }
 // 8 word SSE
 template<typename T, int ABI, typename Int,
          typename std::enable_if<sizeof(T)==8 && ABI==128,bool>::type=0>
-FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride) {
+FASTOR_INLINE void data_setter(T *FASTOR_RESTRICT data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride) {
     data[idx] = vec[0];
     data[idx+general_stride] = vec[1];
 }
 // 8 word AVX
 template<typename T, int ABI, typename Int,
          typename std::enable_if<sizeof(T)==8 && ABI==256,bool>::type=0>
-FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride) {
+FASTOR_INLINE void data_setter(T *FASTOR_RESTRICT data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride) {
     data[idx] = vec[0];
     data[idx+general_stride] = vec[1];
     data[idx+2*general_stride] = vec[2];
@@ -314,7 +314,7 @@ FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &ve
 // 8 word AVX 512
 template<typename T, int ABI, typename Int,
          typename std::enable_if<sizeof(T)==8 && ABI==512,bool>::type=0>
-FASTOR_INLINE void data_setter(T *__restrict__ data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride) {
+FASTOR_INLINE void data_setter(T *FASTOR_RESTRICT data, const SIMDVector<T,ABI> &vec, Int idx, int general_stride) {
     data[idx] = vec[0];
     data[idx+general_stride] = vec[1];
     data[idx+2*general_stride] = vec[2];


### PR DESCRIPTION
Necessary if MSVC compliance is expected in the future.

If it is not the case then feel free to decline, it is working quite well with Windows Subsystem for Linux so far.