### PR TITLE
Fix/simd vector int64

### DIFF
--- a/simd_vector/simd_vector_int64.h
+++ b/simd_vector/simd_vector_int64.h
@@ -97,16 +97,16 @@ struct SIMDVector<Int64,256> {
     }
 
     FASTOR_INLINE Int64 minimum() {
-		auto vals = reinterpret_cast<const Int64*>(&value);
-		Int64 quan = 0;
+        auto vals = reinterpret_cast<const Int64*>(&value);
+        Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             if (vals[i]<quan)
                 quan = vals[i];
         return quan;
     }
     FASTOR_INLINE Int64 maximum() {
-		auto vals = reinterpret_cast<const Int64*>(&value);
-		Int64 quan = 0;
+        auto vals = reinterpret_cast<const Int64*>(&value);
+        Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             if (vals[i]>quan)
                 quan = vals[i];
@@ -124,17 +124,17 @@ struct SIMDVector<Int64,256> {
     }
 
     FASTOR_INLINE Int64 sum() {
-		auto vals = reinterpret_cast<const Int64*>(&value);
-		Int64 quan = 0;
+        auto vals = reinterpret_cast<const Int64*>(&value);
+        Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             quan += vals[i];
         return quan;
     }
 
     FASTOR_INLINE Int64 dot(const SIMDVector<Int64> &other) {
-		auto vals0 = reinterpret_cast<const Int64*>(&value);
-		auto vals1 = reinterpret_cast<const Int64*>(&other.value);
-		Int64 quan = 0;
+        auto vals0 = reinterpret_cast<const Int64*>(&value);
+        auto vals1 = reinterpret_cast<const Int64*>(&other.value);
+        Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             quan += vals0[i]*vals1[i];
         return quan;
@@ -144,8 +144,8 @@ struct SIMDVector<Int64,256> {
 };
 
 FASTOR_HINT_INLINE std::ostream& operator<<(std::ostream &os, SIMDVector<Int64> a) {
-	auto value = reinterpret_cast<const Int64*>(&a.value);
-	os << "[" << value[0] <<  " " << value[1] << " " << value[2] << " " << value[3] << "]\n";
+    auto value = reinterpret_cast<const Int64*>(&a.value);
+    os << "[" << value[0] <<  " " << value[1] << " " << value[2] << " " << value[3] << "]\n";
     return os;
 }
 
@@ -234,8 +234,8 @@ struct SIMDVector<Int64,128> {
     FASTOR_INLINE SIMDVector(Int64 *data) : value(_mm_load_si128((__m128i*)data)) {}
 
     FASTOR_INLINE SIMDVector<Int64,128> operator=(Int64 num) {
-		value = _mm_set_epi64x(num, num);
-		value = _mm_shuffle_epi32(value,0x8);
+        value = _mm_set_epi64x(num, num);
+        value = _mm_shuffle_epi32(value,0x8);
         return *this;
     }
     FASTOR_INLINE SIMDVector<Int64,128> operator=(__m128i regi) {
@@ -264,8 +264,8 @@ struct SIMDVector<Int64,128> {
     FASTOR_INLINE Int64 operator()(FASTOR_INDEX i) const {return value[i];}
 
     FASTOR_INLINE void set(Int64 num) {
-		value = _mm_set_epi64x(num, num);
-		value = _mm_shuffle_epi32(value,0x8);
+        value = _mm_set_epi64x(num, num);
+        value = _mm_shuffle_epi32(value,0x8);
     }
     FASTOR_INLINE void set(Int64 num0, Int64 num1) {
         value = _mm_set_epi64x(num0,num1);
@@ -302,8 +302,8 @@ struct SIMDVector<Int64,128> {
     }
 
     FASTOR_INLINE void operator*=(Int64 num) {
-		auto numb = _mm_set_epi64x(num, num);
-		numb = _mm_shuffle_epi32(numb,0x8);
+        auto numb = _mm_set_epi64x(num, num);
+        numb = _mm_shuffle_epi32(numb,0x8);
         value = _mm_mul_epi64(value,numb);
     }
     FASTOR_INLINE void operator*=(__m128i regi) {
@@ -314,16 +314,16 @@ struct SIMDVector<Int64,128> {
     }
 
     FASTOR_INLINE Int64 minimum() {
-		auto vals = reinterpret_cast<const Int64*>(&value);
-		Int64 quan = 0;
+        auto vals = reinterpret_cast<const Int64*>(&value);
+        Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             if (vals[i]<quan)
                 quan = vals[i];
         return quan;
     }
     FASTOR_INLINE Int64 maximum() {
-		auto vals = reinterpret_cast<const Int64*>(&value);
-		Int64 quan = 0;
+        auto vals = reinterpret_cast<const Int64*>(&value);
+        Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             if (vals[i]>quan)
                 quan = vals[i];
@@ -336,17 +336,17 @@ struct SIMDVector<Int64,128> {
     }
 
     FASTOR_INLINE Int64 sum() {
-		auto vals = reinterpret_cast<const Int64*>(&value);
-		Int64 quan = 0;
+        auto vals = reinterpret_cast<const Int64*>(&value);
+        Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<2; ++i)
             quan += vals[i];
         return quan;
     }
 
     FASTOR_INLINE Int64 dot(const SIMDVector<Int64,128> &other) {
-		auto vals0 = reinterpret_cast<const Int64*>(&value);
-		auto vals1 = reinterpret_cast<const Int64*>(&other.value);
-		Int64 quan = 0;
+        auto vals0 = reinterpret_cast<const Int64*>(&value);
+        auto vals1 = reinterpret_cast<const Int64*>(&other.value);
+        Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<2; ++i)
             quan += vals0[i]*vals1[i];
         return quan;
@@ -356,8 +356,8 @@ struct SIMDVector<Int64,128> {
 };
 
 FASTOR_HINT_INLINE std::ostream& operator<<(std::ostream &os, SIMDVector<Int64,128> a) {
-	auto value = reinterpret_cast<const Int64*>(&a.value);
-	os << "[" << value[0] <<  " " << value[1] << "]\n";
+    auto value = reinterpret_cast<const Int64*>(&a.value);
+    os << "[" << value[0] <<  " " << value[1] << "]\n";
     return os;
 }
 
@@ -368,15 +368,15 @@ FASTOR_INLINE SIMDVector<Int64,128> operator+(const SIMDVector<Int64,128> &a, co
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator+(const SIMDVector<Int64,128> &a, Int64 b) {
     SIMDVector<Int64,128> out;
-	auto numb = _mm_set_epi64x(b, b);
-	numb = _mm_shuffle_epi32(numb,0x8);
+    auto numb = _mm_set_epi64x(b, b);
+    numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_add_epi32(a.value,numb);
     return out;
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator+(Int64 a, const SIMDVector<Int64,128> &b) {
     SIMDVector<Int64,128> out;
-	auto numb = _mm_set_epi64x(a, a);
-	numb = _mm_shuffle_epi32(numb,0x8);
+    auto numb = _mm_set_epi64x(a, a);
+    numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_add_epi32(numb,b.value);
     return out;
 }
@@ -391,15 +391,15 @@ FASTOR_INLINE SIMDVector<Int64,128> operator-(const SIMDVector<Int64,128> &a, co
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator-(const SIMDVector<Int64,128> &a, Int64 b) {
     SIMDVector<Int64,128> out;
-	auto numb = _mm_set_epi64x(b, b);
-	numb = _mm_shuffle_epi32(numb,0x8);
+    auto numb = _mm_set_epi64x(b, b);
+    numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_sub_epi32(a.value,numb);
     return out;
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator-(Int64 a, const SIMDVector<Int64,128> &b) {
     SIMDVector<Int64,128> out;
-	auto numb = _mm_set_epi64x(a, a);
-	numb = _mm_shuffle_epi32(numb,0x8);
+    auto numb = _mm_set_epi64x(a, a);
+    numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_sub_epi32(numb,b.value);
     return out;
 }
@@ -416,15 +416,15 @@ FASTOR_INLINE SIMDVector<Int64,128> operator*(const SIMDVector<Int64,128> &a, co
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator*(const SIMDVector<Int64,128> &a, Int64 b) {
     SIMDVector<Int64,128> out;
-	auto numb = _mm_set_epi64x(b, b);
-	numb = _mm_shuffle_epi32(numb,0x8);
+    auto numb = _mm_set_epi64x(b, b);
+    numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_mul_epi64(a.value,numb);
     return out;
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator*(Int64 a, const SIMDVector<Int64,128> &b) {
     SIMDVector<Int64,128> out;
-	auto numb = _mm_set_epi64x(a, a);
-	numb = _mm_shuffle_epi32(numb,0x8);
+    auto numb = _mm_set_epi64x(a, a);
+    numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_mul_epi64(numb,b.value);
     return out;
 }

--- a/simd_vector/simd_vector_int64.h
+++ b/simd_vector/simd_vector_int64.h
@@ -225,7 +225,7 @@ struct SIMDVector<Int64,128> {
 
     FASTOR_INLINE SIMDVector() : value(_mm_setzero_si128()) {}
     FASTOR_INLINE SIMDVector(Int64 num) {
-        value = _mm_set_epi64((__m64)num,(__m64)num);
+        value = _mm_set_epi64x(num,num);
         value = _mm_shuffle_epi32(value,0x8);
     }
     FASTOR_INLINE SIMDVector(__m128i regi) : value(regi) {}
@@ -234,8 +234,8 @@ struct SIMDVector<Int64,128> {
     FASTOR_INLINE SIMDVector(Int64 *data) : value(_mm_load_si128((__m128i*)data)) {}
 
     FASTOR_INLINE SIMDVector<Int64,128> operator=(Int64 num) {
-        value = _mm_set_epi64((__m64)num, (__m64)num);
-        value = _mm_shuffle_epi32(value,0x8);
+		value = _mm_set_epi64x(num, num);
+		value = _mm_shuffle_epi32(value,0x8);
         return *this;
     }
     FASTOR_INLINE SIMDVector<Int64,128> operator=(__m128i regi) {
@@ -264,21 +264,21 @@ struct SIMDVector<Int64,128> {
     FASTOR_INLINE Int64 operator()(FASTOR_INDEX i) const {return value[i];}
 
     FASTOR_INLINE void set(Int64 num) {
-        value = _mm_set_epi64((__m64)num,(__m64)num);
-        value = _mm_shuffle_epi32(value,0x8);
+		value = _mm_set_epi64x(num, num);
+		value = _mm_shuffle_epi32(value,0x8);
     }
     FASTOR_INLINE void set(Int64 num0, Int64 num1) {
-        value = _mm_set_epi64((__m64)num0,(__m64)num1);
+        value = _mm_set_epi64x(num0,num1);
         value = _mm_shuffle_epi32(value,0x8);
     }
     FASTOR_INLINE void set_sequential(Int64 num0) {
-        value = _mm_setr_epi64((__m64)num0,(__m64)(num0+1));
+        value = _mm_setr_epi64x(num0,num0+1);
         value = _mm_shuffle_epi32(value,0x8);
     }
 
     // In-place operators
     FASTOR_INLINE void operator+=(Int64 num) {
-        auto numb = _mm_set_epi64((__m64)num,(__m64)num);
+        auto numb = _mm_set_epi64x(num,num);
         numb = _mm_shuffle_epi32(numb,0x8);
         value = _mm_add_epi32(value,numb);
     }
@@ -290,7 +290,7 @@ struct SIMDVector<Int64,128> {
     }
 
     FASTOR_INLINE void operator-=(Int64 num) {
-        auto numb = _mm_set_epi64((__m64)num,(__m64)num);
+        auto numb = _mm_set_epi64x(num,num);
         numb = _mm_shuffle_epi32(numb,0x8);
         value = _mm_sub_epi32(value,numb);
     }
@@ -302,8 +302,8 @@ struct SIMDVector<Int64,128> {
     }
 
     FASTOR_INLINE void operator*=(Int64 num) {
-        auto numb = _mm_set_epi64((__m64)num,(__m64)num);
-        numb = _mm_shuffle_epi32(numb,0x8);
+		auto numb = _mm_set_epi64x(num, num);
+		numb = _mm_shuffle_epi32(numb,0x8);
         value = _mm_mul_epi64(value,numb);
     }
     FASTOR_INLINE void operator*=(__m128i regi) {
@@ -368,15 +368,15 @@ FASTOR_INLINE SIMDVector<Int64,128> operator+(const SIMDVector<Int64,128> &a, co
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator+(const SIMDVector<Int64,128> &a, Int64 b) {
     SIMDVector<Int64,128> out;
-    auto numb = _mm_set_epi64((__m64)b,(__m64)b);
-    numb = _mm_shuffle_epi32(numb,0x8);
+	auto numb = _mm_set_epi64x(b, b);
+	numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_add_epi32(a.value,numb);
     return out;
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator+(Int64 a, const SIMDVector<Int64,128> &b) {
     SIMDVector<Int64,128> out;
-    auto numb = _mm_set_epi64((__m64)a,(__m64)a);
-    numb = _mm_shuffle_epi32(numb,0x8);
+	auto numb = _mm_set_epi64x(a, a);
+	numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_add_epi32(numb,b.value);
     return out;
 }
@@ -391,15 +391,15 @@ FASTOR_INLINE SIMDVector<Int64,128> operator-(const SIMDVector<Int64,128> &a, co
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator-(const SIMDVector<Int64,128> &a, Int64 b) {
     SIMDVector<Int64,128> out;
-    auto numb = _mm_set_epi64((__m64)b,(__m64)b);
-    numb = _mm_shuffle_epi32(numb,0x8);
+	auto numb = _mm_set_epi64x(b, b);
+	numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_sub_epi32(a.value,numb);
     return out;
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator-(Int64 a, const SIMDVector<Int64,128> &b) {
     SIMDVector<Int64,128> out;
-    auto numb = _mm_set_epi64((__m64)a,(__m64)a);
-    numb = _mm_shuffle_epi32(numb,0x8);
+	auto numb = _mm_set_epi64x(a, a);
+	numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_sub_epi32(numb,b.value);
     return out;
 }
@@ -416,15 +416,15 @@ FASTOR_INLINE SIMDVector<Int64,128> operator*(const SIMDVector<Int64,128> &a, co
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator*(const SIMDVector<Int64,128> &a, Int64 b) {
     SIMDVector<Int64,128> out;
-    auto numb = _mm_set_epi64((__m64)b,(__m64)b);
-    numb = _mm_shuffle_epi32(numb,0x8);
+	auto numb = _mm_set_epi64x(b, b);
+	numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_mul_epi64(a.value,numb);
     return out;
 }
 FASTOR_INLINE SIMDVector<Int64,128> operator*(Int64 a, const SIMDVector<Int64,128> &b) {
     SIMDVector<Int64,128> out;
-    auto numb = _mm_set_epi64((__m64)a,(__m64)a);
-    numb = _mm_shuffle_epi32(numb,0x8);
+	auto numb = _mm_set_epi64x(a, a);
+	numb = _mm_shuffle_epi32(numb,0x8);
     out.value = _mm_mul_epi64(numb,b.value);
     return out;
 }

--- a/simd_vector/simd_vector_int64.h
+++ b/simd_vector/simd_vector_int64.h
@@ -97,16 +97,16 @@ struct SIMDVector<Int64,256> {
     }
 
     FASTOR_INLINE Int64 minimum() {
-        Int64 *vals = (Int64*)&value;
-        Int64 quan = 0;
+		auto vals = reinterpret_cast<const Int64*>(&value);
+		Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             if (vals[i]<quan)
                 quan = vals[i];
         return quan;
     }
     FASTOR_INLINE Int64 maximum() {
-        Int64 *vals = (Int64*)&value;
-        Int64 quan = 0;
+		auto vals = reinterpret_cast<const Int64*>(&value);
+		Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             if (vals[i]>quan)
                 quan = vals[i];
@@ -124,17 +124,17 @@ struct SIMDVector<Int64,256> {
     }
 
     FASTOR_INLINE Int64 sum() {
-        Int64 *vals = (Int64*)&value;
-        Int64 quan = 0;
+		auto vals = reinterpret_cast<const Int64*>(&value);
+		Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             quan += vals[i];
         return quan;
     }
 
     FASTOR_INLINE Int64 dot(const SIMDVector<Int64> &other) {
-        Int64 *vals0 = (Int64*)&value;
-        Int64 *vals1 = (Int64*)&other.value;
-        Int64 quan = 0;
+		auto vals0 = reinterpret_cast<const Int64*>(&value);
+		auto vals1 = reinterpret_cast<const Int64*>(&other.value);
+		Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             quan += vals0[i]*vals1[i];
         return quan;
@@ -144,8 +144,8 @@ struct SIMDVector<Int64,256> {
 };
 
 FASTOR_HINT_INLINE std::ostream& operator<<(std::ostream &os, SIMDVector<Int64> a) {
-    const int *value = (int*) &a.value;
-    os << "[" << value[0] <<  " " << value[1] << " " << value[2] << " " << value[3] << "]\n";
+	auto value = reinterpret_cast<const Int64*>(&a.value);
+	os << "[" << value[0] <<  " " << value[1] << " " << value[2] << " " << value[3] << "]\n";
     return os;
 }
 
@@ -314,20 +314,20 @@ struct SIMDVector<Int64,128> {
     }
 
     FASTOR_INLINE Int64 minimum() {
-        int *vals = (int*)&value;
-        int quan = 0;
+		auto vals = reinterpret_cast<const Int64*>(&value);
+		Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             if (vals[i]<quan)
                 quan = vals[i];
-        return static_cast<Int64>(quan);
+        return quan;
     }
     FASTOR_INLINE Int64 maximum() {
-        int *vals = (int*)&value;
-        int quan = 0;
+		auto vals = reinterpret_cast<const Int64*>(&value);
+		Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<Size; ++i)
             if (vals[i]>quan)
                 quan = vals[i];
-        return static_cast<Int64>(quan);
+        return quan;
     }
     FASTOR_INLINE SIMDVector<Int64,128> reverse() {
         SIMDVector<Int64,128> out;
@@ -336,28 +336,28 @@ struct SIMDVector<Int64,128> {
     }
 
     FASTOR_INLINE Int64 sum() {
-        int *vals = (int*)&value;
-        int quan = 0;
+		auto vals = reinterpret_cast<const Int64*>(&value);
+		Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<2; ++i)
             quan += vals[i];
-        return static_cast<Int64>(quan);
+        return quan;
     }
 
     FASTOR_INLINE Int64 dot(const SIMDVector<Int64,128> &other) {
-        int *vals0 = (int*)&value;
-        int *vals1 = (int*)&other.value;
-        int quan = 0;
+		auto vals0 = reinterpret_cast<const Int64*>(&value);
+		auto vals1 = reinterpret_cast<const Int64*>(&other.value);
+		Int64 quan = 0;
         for (FASTOR_INDEX i=0; i<2; ++i)
             quan += vals0[i]*vals1[i];
-        return static_cast<Int64>(quan);
+        return quan;
     }
 
     __m128i value;
 };
 
 FASTOR_HINT_INLINE std::ostream& operator<<(std::ostream &os, SIMDVector<Int64,128> a) {
-    const int *value = (int*) &a.value;
-    os << "[" << value[0] <<  " " << value[1] << "]\n";
+	auto value = reinterpret_cast<const Int64*>(&a.value);
+	os << "[" << value[0] <<  " " << value[1] << "]\n";
     return os;
 }
 


### PR DESCRIPTION
* Change casting using reinterpret_cast<const Int64*> instead of raw (Int64*)
* Fix some type issues, i.e. using int instead of Int64 desired ?
* Use a more appropriate SIMD function set_epi64x (also SS2, see [Intel intrinsics](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_set_epi&expand=4614,4612&techs=SSE2) to set simd register to __int64 types)

According to [cppreference](http://en.cppreference.com/w/cpp/language/reinterpret_cast), no runtime/assembly should occur due to reinterpret_cast as: 

> Unlike static_cast, but like const_cast, the reinterpret_cast expression does not compile to any CPU instructions. It is purely a compiler directive which instructs the compiler to treat the sequence of bits (object representation) of expression as if it had the type new_type.