### PR TITLE
Assignment from `TensorMap` wrapping a `const` type

### DIFF
--- a/Fastor/simd_vector/simd_vector_common.h
+++ b/Fastor/simd_vector/simd_vector_common.h
@@ -599,6 +599,8 @@ void maskstore(std::complex<double> * FASTOR_RESTRICT a, const int (&maska)[4], 
     _mm256_maskstore_pd(reinterpret_cast<double*>(a  ), (__m256i) mask0, lo);
     _mm256_maskstore_pd(reinterpret_cast<double*>(a+2), (__m256i) mask1, hi);
 }
+template<>
+FASTOR_INLINE
 void maskstore(std::complex<float> * FASTOR_RESTRICT a, const int (&maska)[8], SIMDVector<std::complex<float>,simd_abi::avx> &v) {
     // Split the mask in to a higher and lower part - we need two masks for this
     __m256i mask0 = _mm256_set_epi32(maska[4],maska[4],maska[5],maska[5],maska[6],maska[6],maska[7],maska[7]);

--- a/Fastor/tensor/TensorEvaluator.h
+++ b/Fastor/tensor/TensorEvaluator.h
@@ -4,8 +4,8 @@
 // Expression templates evaluators
 //----------------------------------------------------------------------------------------------------------//
 template<typename U=T>
-FASTOR_INLINE SIMDVector<T,simd_abi_type> eval(FASTOR_INDEX i) const {
-    SIMDVector<T,simd_abi_type> _vec;
+FASTOR_INLINE SIMDVector<U,simd_abi_type> eval(FASTOR_INDEX i) const {
+    SIMDVector<U,simd_abi_type> _vec;
     _vec.load(&_data[get_mem_index(i)],false);
     return _vec;
 }
@@ -14,8 +14,8 @@ FASTOR_INLINE T eval_s(FASTOR_INDEX i) const {
     return _data[get_mem_index(i)];
 }
 template<typename U=T>
-FASTOR_INLINE SIMDVector<T,simd_abi_type> eval(FASTOR_INDEX i, FASTOR_INDEX j) const {
-    SIMDVector<T,simd_abi_type> _vec;
+FASTOR_INLINE SIMDVector<U,simd_abi_type> eval(FASTOR_INDEX i, FASTOR_INDEX j) const {
+    SIMDVector<U,simd_abi_type> _vec;
     _vec.load(&_data[get_flat_index(i,j)],false);
     return _vec;
 }
@@ -25,8 +25,8 @@ FASTOR_INLINE T eval_s(FASTOR_INDEX i, FASTOR_INDEX j) const {
 }
 
 template<typename U=T>
-FASTOR_INLINE SIMDVector<T,simd_abi_type> teval(const std::array<int, dimension_t::value> &as) const {
-    SIMDVector<T,simd_abi_type> _vec;
+FASTOR_INLINE SIMDVector<U,simd_abi_type> teval(const std::array<int, dimension_t::value> &as) const {
+    SIMDVector<U,simd_abi_type> _vec;
     _vec.load(&_data[get_flat_index(as)],false);
     return _vec;
 }

--- a/Fastor/tensor/TensorMap.h
+++ b/Fastor/tensor/TensorMap.h
@@ -143,7 +143,7 @@ FASTOR_MAKE_OS_STREAM_TENSORn(TensorMap)
 
 
 template<typename Derived, size_t DIM, typename T, size_t ...Rest>
-FASTOR_INLINE void assign(const AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
+FASTOR_INLINE void assign(AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
     if (dst.self().data()==src.data()) return;
     trivial_assign(dst.self(),src);
 }

--- a/tests/test_tensormap/test_tensormap.cpp
+++ b/tests/test_tensormap/test_tensormap.cpp
@@ -55,6 +55,16 @@ void run() {
         FASTOR_EXIT_ASSERT(abs(a.sum() - ma.sum()) < Tol);
     }
 
+    // Map a const array and copy-assign it to a non-const tensor.
+    {
+        const T data[] = {1, 2, 3};
+        TensorMap<const T, 3> mdata{data};
+        Tensor<T, 3> tdata = mdata;
+        Tensor<T, 3> check{1, 2, 3};
+
+        FASTOR_EXIT_ASSERT(all_of(tdata == check));
+    }
+
     print(FGRN(BOLD("All tests passed successfully")));
 }
 


### PR DESCRIPTION
This is more of a bug report/feature request than a real pull request, since I'm certain the solution (and possibly the problem description) here is incomplete at best.  The additional unit test shows the situation :
```cpp
        const T data[] = {1, 2, 3};
        TensorMap<const T, 3> mdata{data};
        Tensor<T, 3> tdata = mdata;
```
Prior to this patch, the above will not compile.  That is, we cannot assign a `TensorMap` wrapping an array of `const` qualified elements to a `Tensor` containing non-`const` elements.

For background, I came across this issue when wanting to copy the (3-dimensional) positions of the 4 nodes in a tetrahedron into a 4x3 tensor.  Those node positions are passed as `const`-qualified (non-Fastor) vectors, which I attempted to `TensorMap` then assign each in turn to a slice of my `Tensor`.  But of course that didn't work.

This pull request does the very minimum to get the above situation working. I'm happy for you to take it over or replace it, or I can do minor tweaks as requested.  I started using Fastor only a couple of days ago, so I'm probably not the best person to be fiddling ;)

A brief summary of changes:
* Use destination type (e.g. non-`const`) to construct `SIMDVector` in `eval` functions, otherwise we get "assignment of read-only location" errors.
* Don't `const`-qualify destination tensor in `assign`, otherwise overload resolution of called `trivial_assign` fails.
* Missing inline declaration for a `maskstore` overload causing "multiple definition of `Fastor::maskstore`" errors (this is unrelated to the issue of assigning `const` data, but caused compilation errors for me - should probably be a separate PR/issue).
