### PR TITLE
Fix TensorMap compound assignment operators

### DIFF
--- a/Fastor/tensor/TensorMap.h
+++ b/Fastor/tensor/TensorMap.h
@@ -148,19 +148,19 @@ FASTOR_INLINE void assign(AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Re
     trivial_assign(dst.self(),src);
 }
 template<typename Derived, size_t DIM, typename T, size_t ...Rest>
-FASTOR_INLINE void assign_add(const AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
+FASTOR_INLINE void assign_add(AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
     trivial_assign_add(dst.self(),src);
 }
 template<typename Derived, size_t DIM, typename T, size_t ...Rest>
-FASTOR_INLINE void assign_sub(const AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
+FASTOR_INLINE void assign_sub(AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
     trivial_assign_sub(dst.self(),src);
 }
 template<typename Derived, size_t DIM, typename T, size_t ...Rest>
-FASTOR_INLINE void assign_mul(const AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
+FASTOR_INLINE void assign_mul(AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
     trivial_assign_mul(dst.self(),src);
 }
 template<typename Derived, size_t DIM, typename T, size_t ...Rest>
-FASTOR_INLINE void assign_div(const AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
+FASTOR_INLINE void assign_div(AbstractTensor<Derived,DIM> &dst, const TensorMap<T,Rest...> &src) {
     trivial_assign_div(dst.self(),src);
 }
 

--- a/tests/test_tensormap/test_tensormap.cpp
+++ b/tests/test_tensormap/test_tensormap.cpp
@@ -55,6 +55,36 @@ void run() {
         FASTOR_EXIT_ASSERT(std::abs(a.sum() - ma.sum()) < Tol);
     }
 
+    // Compound assignment operators.
+    {
+        Tensor<T,4,5> src;
+        src = 3;
+        TensorMap<T,4,5> msrc(src);
+        Tensor<T,4,5> dst;
+        dst = 0;
+        Tensor<T,4,5> check;
+
+        // +=
+        check = 3;
+        dst += msrc;
+        FASTOR_EXIT_ASSERT(all_of(dst == check));
+
+        // *=
+        check = 9;
+        dst *= msrc;
+        FASTOR_EXIT_ASSERT(all_of(dst == check));
+
+        // -=
+        check = 6;
+        dst -= msrc;
+        FASTOR_EXIT_ASSERT(all_of(dst == check));
+
+        // /=
+        check = 2;
+        dst /= msrc;
+        FASTOR_EXIT_ASSERT(all_of(dst == check));
+    }
+
     // Map a const array and copy-assign it to a non-const tensor.
     {
         const T data[] = {1, 2, 3};


### PR DESCRIPTION
Compound assignment operators such as `+=` are provided where the source
is a `TensorMap` and the destination is an `AbstractTensor`. However,
since the destination tensor was const-qualified, use of these operators
resulted in a compile error.