### PR TITLE
Updated CMake and used `[[maybe_unused]]` if available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(fastor VERSION 0.6.4)
+project(fastor VERSION 0.6.4 LANGUAGES CXX)
+
+# specify the C++ standard
+set(CMAKE_CXX_STANDARD 14)
 
 option(BUILD_TESTING "Build the testing tree." ON)
 

--- a/Fastor/config/config.h
+++ b/Fastor/config/config.h
@@ -121,7 +121,7 @@ SOFTWARE.
         #define FASTOR_CXX_VERSION 2014
     #elif __cplusplus == 201703L
         #define FASTOR_CXX_VERSION 2017
-    #elif __cplusplus > 201703L
+    #elif __cplusplus > 202002L
         #define FASTOR_CXX_VERSION 2020
     #endif
 #endif
@@ -159,6 +159,18 @@ SOFTWARE.
 #else
     #define FASTOR_HAS_IF_CONSTEXPR 0
     #define FASTOR_IF_CONSTEXPR if
+#endif
+//------------------------------------------------------------------------------------------------//
+
+
+// C++17 [[maybe_unused]] define
+//------------------------------------------------------------------------------------------------//
+#if FASTOR_CXX_VERSION >= 2017
+    #define FASTOR_MAYBE_UNUSED [[maybe_unused]]
+#elif defined(__GNUC__) || defined(__clang__)
+    #define FASTOR_MAYBE_UNUSED [[gnu::unused]]
+#elif defined(_MSC_VER)
+#define FASTOR_MAYBE_UNUSED __declspec(maybe_unused)
 #endif
 //------------------------------------------------------------------------------------------------//
 

--- a/Fastor/util/extended_algorithms.h
+++ b/Fastor/util/extended_algorithms.h
@@ -74,11 +74,11 @@ inline size_t set_stack_size(size_t size) {
 
 // Get sign of a number
 template <typename T>
-inline constexpr int signum(T x, [[gnu::unused]] std::false_type is_signed) {
+inline constexpr int signum(T x, FASTOR_MAYBE_UNUSED std::false_type is_signed) {
     return T(0) < x;
 }
 template <typename T>
-inline constexpr int signum(T x, [[gnu::unused]] std::true_type is_signed) {
+inline constexpr int signum(T x, FASTOR_MAYBE_UNUSED std::true_type is_signed) {
     return (T(0) < x) - (x < T(0));
 }
 template <typename T>


### PR DESCRIPTION
In the top-level, `CMakeLists.txt` I specificed the project language and also put the C++ version language as 14 because in [`Fastor/config/config.h`](https://github.com/romeric/Fastor/blob/e96e63fe8a05898d732d0b9faba3667d9a25a38f/Fastor/config/config.h#L37-L48), the compilation is set to error out if the compiler doesn't at least support C++14.

I also modified the test for C++20 because after the release of C++20, the proper way to check for support is to check if `__cplusplus` is defined to be `202002L` or not.

Finally, I changed the use of the `[[gnu::unused]]` to `[[maybe_unused]]` if available and compiler-specific pragmas otherwise, because `[[gnu::unused]]` was emitting error `C5030` on MSVC v19.35 (`attribute 'gnu::unused' is not recognized`).