### PR TITLE
Hide enable_testing() under PROJECT_IS_TOP_LEVEL condition.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(fastor VERSION 0.6.4)
 
-option(BUILD_TESTING "Build the testing tree." ON)
+if(PROJECT_IS_TOP_LEVEL)
+	option(FASTOR_BUILD_TESTING "Build the testing tree." ON)
+endif()
 
 set(FASTOR_SOURCE_DIR "${fastor_SOURCE_DIR}")
 set(FASTOR_BINARY_DIR "${fastor_BINARY_DIR}")
@@ -21,9 +23,8 @@ target_include_directories(
         $<BUILD_INTERFACE:${FASTOR_INCLUDE_DIR}>
         $<INSTALL_INTERFACE:${FASTOR_INSTALL_INCLUDE_DIR}>)
 
-if(BUILD_TESTING)
+if(FASTOR_BUILD_TESTING)
     enable_testing()
-
     add_subdirectory(tests)
 endif()
 

--- a/benchmark/benchmark_finite_difference/CMakeLists.txt
+++ b/benchmark/benchmark_finite_difference/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.21)
 project(benchmark_finite_difference)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/benchmark/benchmark_material/CMakeLists.txt
+++ b/benchmark/benchmark_material/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.21)
 project(benchmark_material)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,9 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_fastor)
 
 set(FASTOR_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../)
 
 set(CMAKE_CXX_STANDARD 14)
-
-enable_testing()
 
 if(MSVC)
     add_compile_options("/std:c++17" "/W2" "$<$<CONFIG:RELEASE>:/O2>")

--- a/tests/test_auxiliary_funcs/CMakeLists.txt
+++ b/tests/test_auxiliary_funcs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_auxiliary_funcs)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_binary_cmp_ops/CMakeLists.txt
+++ b/tests/test_binary_cmp_ops/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_binary_cmp_ops)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_booleans/CMakeLists.txt
+++ b/tests/test_booleans/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_booleans)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_complex_expressions/CMakeLists.txt
+++ b/tests/test_complex_expressions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_complex_expressions)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_einsum/CMakeLists.txt
+++ b/tests/test_einsum/CMakeLists.txt
@@ -1,9 +1,7 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_einsum)
 
 set(CMAKE_CXX_STANDARD 14)
-
-enable_testing()
 
 # single einsum
 # MSVC gives superfluous errors

--- a/tests/test_einsum_explicit/CMakeLists.txt
+++ b/tests/test_einsum_explicit/CMakeLists.txt
@@ -1,9 +1,8 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_einsum)
 
 set(CMAKE_CXX_STANDARD 17)
 
-enable_testing()
 
 # explicit einsum
 # single expressions

--- a/tests/test_fixed_views_1d/CMakeLists.txt
+++ b/tests/test_fixed_views_1d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_fixed_views_1d)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_fixed_views_2d/CMakeLists.txt
+++ b/tests/test_fixed_views_2d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_fixed_views_2d)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_fixed_views_nd/CMakeLists.txt
+++ b/tests/test_fixed_views_nd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_fixed_views_nd)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_inverse/CMakeLists.txt
+++ b/tests/test_inverse/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_inverse)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_linalg/CMakeLists.txt
+++ b/tests/test_linalg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_linalg)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_lu/CMakeLists.txt
+++ b/tests/test_lu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_lu)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_math_functions/CMakeLists.txt
+++ b/tests/test_math_functions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_math_functions)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_matmul/CMakeLists.txt
+++ b/tests/test_matmul/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_matmul)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_mixed_views/CMakeLists.txt
+++ b/tests/test_mixed_views/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_mixed_views)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_numerics/CMakeLists.txt
+++ b/tests/test_numerics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_numerics)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_permute/CMakeLists.txt
+++ b/tests/test_permute/CMakeLists.txt
@@ -1,9 +1,8 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_permute)
 
 set(CMAKE_CXX_STANDARD 14)
 
-enable_testing()
 
 # default recursive CXX14
 add_executable(test_permute_1 test_permute.cpp)

--- a/tests/test_qr/CMakeLists.txt
+++ b/tests/test_qr/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_qr)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_random_views/CMakeLists.txt
+++ b/tests/test_random_views/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_random_views)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_simd_vectors/CMakeLists.txt
+++ b/tests/test_simd_vectors/CMakeLists.txt
@@ -1,10 +1,7 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_simd_vectors)
 
 set(CMAKE_CXX_STANDARD 14)
-
-enable_testing()
-
 
 add_executable(test_simd_vectors test_simd_vectors.cpp)
 add_test(test_simd_vectors test_simd_vectors)

--- a/tests/test_solve/CMakeLists.txt
+++ b/tests/test_solve/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_solve)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_tensor_basics/CMakeLists.txt
+++ b/tests/test_tensor_basics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_tensor_basics)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_tensormap/CMakeLists.txt
+++ b/tests/test_tensormap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_tensormap)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_tmatmul/CMakeLists.txt
+++ b/tests/test_tmatmul/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_tmatmul)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_transpose/CMakeLists.txt
+++ b/tests/test_transpose/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_transpose)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_unary_bool_ops/CMakeLists.txt
+++ b/tests/test_unary_bool_ops/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_unary_bool_ops)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_views_1d/CMakeLists.txt
+++ b/tests/test_views_1d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_views_1d)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_views_2d/CMakeLists.txt
+++ b/tests/test_views_2d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_views_2d)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tests/test_views_nd/CMakeLists.txt
+++ b/tests/test_views_nd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(test_views_nd)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
1. Bump cmake version to 3.21.
2. Create new FASTOR_ENABLE_TESTING option 3, Check if project is top level (not a dependency)
4. remove redundant enable_testing() from lower level CMakeFile.txt's