### PR TITLE
Guard CPUID/rdtsc for non-x86 and add stubs

### DIFF
--- a/Fastor/config/cpuid.h
+++ b/Fastor/config/cpuid.h
@@ -43,11 +43,14 @@ public:
 #ifdef _WIN32
     __cpuid((int *)regs, (int)i);
 
-#else
+#elif defined(__x86_64__) || defined(__i386__)
     asm volatile
       ("cpuid" : "=a" (regs[0]), "=b" (regs[1]), "=c" (regs[2]), "=d" (regs[3])
        : "a" (i), "c" (0));
     // ECX is set to zero for CPUID function 4
+#else
+    (void)i;
+    regs[0] = regs[1] = regs[2] = regs[3] = 0;
 #endif
   }
 

--- a/Fastor/util/timeit.h
+++ b/Fastor/util/timeit.h
@@ -101,7 +101,7 @@ inline uint64_t rdtsc_end() {
     return __rdtsc();
 }
 //  Linux/GCC
-#else
+#elif defined(__x86_64__) || defined(__i386__)
 inline uint64_t rdtsc() {
     unsigned int lo, hi;
     // This does not clobber the register so rdtsc overwrites
@@ -158,6 +158,11 @@ inline uint64_t rdtsc_end() {
 inline uint64_t rdtsc_begin() { return rdtsc();}
 inline uint64_t rdtsc_end() { return rdtsc();}
 #endif
+#else
+// ARM/non-x86 stubs
+inline uint64_t rdtsc() { return 0; }
+inline uint64_t rdtsc_begin() { return 0; }
+inline uint64_t rdtsc_end() { return 0; }
 #endif
 
 


### PR DESCRIPTION
Proposed fix for ARM: 

  Fastor/config/cpuid.h — The CPUID class constructor uses x86 cpuid asm in an unguarded #else. Fix: gate it with #elif defined(__x86_64__) || defined(__i386__)
  and add an #else that zeros the registers on ARM.

  Fastor/util/timeit.h — The rdtsc() / rdtsc_begin() / rdtsc_end() functions use x86 rdtsc/rdtscp asm in an unguarded #else. Fix: same #elif x86 gate, plus ARM
  stubs that return 0.

